### PR TITLE
Fix interface priority bug when either of IPv4/IPv6 is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "wsl2-dns-agent"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "configparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsl2-dns-agent"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "GPL-3.0"
 description = "An agent that automatically patches your WSL2 DNS configuration for users of Cisco AnyConnect (or similar VPNs)"


### PR DESCRIPTION
According to Windows, when IPv6 is disabled then the adapter has an IPv6 metric of zero. This was causing adapters to be incorrectly sorted, and DNS servers to be written in the wrong order.
